### PR TITLE
Fix metrics database not getting written back to the host filesystem

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,13 +34,13 @@ jobs:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
-      - uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      - uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       attestations: write
       id-token: write
     outputs:
-      digest: ${{ steps.push.outputs.digest }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -35,21 +35,37 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        id: push
+        id: build
         with:
           platforms: linux/amd64,linux/arm64
+          load: true
           push: ${{ github.event_name == 'push' }}
           secrets: |
             CACHIX_AUTH_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN }}
             CACHIX_CACHE_NAME=${{ vars.CACHIX_CACHE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - uses: ./setup/
+        with:
+          digest: ${{ steps.build.outputs.digest }}
+      - name: Smoke test
+        run: |
+          tinyalert --help
+          tinyalert \
+            --db tinyalert.sqlite \
+            measure \
+            --config integration/smoke.toml \
+            --metrics smoke
+          if [ ! -f tinyalert.sqlite ]; then
+            echo "Expected tinyalert.sqlite to be created"
+            exit 1
+          fi
       - if: ${{ github.event_name == 'push' }}
         name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
   docker-smoke-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+      - uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         id: build
         with:
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,16 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
+      # Enable containerd for multi-arch support when using docker exporter
+      # https://github.com/docker/buildx/issues/59
+      - uses: crazy-max/ghaction-setup-docker@26145a578dce008fee793528d031cd72c57d51af # v3.4.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,3 +89,12 @@ jobs:
           digest: ${{ needs.release-docker.outputs.digest }}
       - run: |
           tinyalert --help
+          tinyalert --db tinyalert.sqlite \
+            measure \
+            --config integration/smoke.toml \
+            --metrics smoke
+          if [ ! -f tinyalert.sqlite ]; then
+            echo "Expected tinyalert.sqlite to be created"
+            exit 1
+          fi
+          ls -l

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,7 @@ jobs:
             echo "Expected tinyalert.sqlite to be created"
             exit 1
           fi
+          ls -l
       - if: ${{ github.event_name == 'push' }}
         name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,17 +59,16 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          docker images
+          export TINYALERT_DB_PATH=smoke.sqlite
+          export TINYALERT_CONFIG=integration/smoke.toml
           docker run --rm -v $(pwd):/work $REGISTRY/$IMAGE_NAME@$DIGEST \
-            --db tinyalert.sqlite \
             measure \
-            --config integration/smoke.toml \
             --metrics smoke
-          if [ ! -f tinyalert.sqlite ]; then
+          if [ ! -f "$TINYALERT_DB_PATH" ]; then
             echo "Expected tinyalert.sqlite to be created"
+            ls -l
             exit 1
           fi
-          ls -l
       - if: ${{ github.event_name == 'push' }}
         name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
@@ -89,12 +88,11 @@ jobs:
           digest: ${{ needs.release-docker.outputs.digest }}
       - run: |
           tinyalert --help
-          tinyalert --db tinyalert.sqlite \
-            measure \
-            --config integration/smoke.toml \
-            --metrics smoke
-          if [ ! -f tinyalert.sqlite ]; then
+          export TINYALERT_DB_PATH=smoke.sqlite
+          export TINYALERT_CONFIG=integration/smoke.toml
+          tinyalert measure --metrics smoke
+          if [ ! -f "$TINYALERT_DB_PATH" ]; then
             echo "Expected tinyalert.sqlite to be created"
+            ls -l
             exit 1
           fi
-          ls -l

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,12 @@ jobs:
         run: |
           export TINYALERT_DB_PATH=smoke.sqlite
           export TINYALERT_CONFIG=integration/smoke.toml
-          docker run --rm -v $(pwd):/work $REGISTRY/$IMAGE_NAME@$DIGEST \
+          docker \
+            run \
+            --rm \
+            -v $(pwd):/work \
+            --env-file <(env | grep TINYALERT_) \
+            $REGISTRY/$IMAGE_NAME@$DIGEST \
             measure \
             --metrics smoke
           if [ ! -f "$TINYALERT_DB_PATH" ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,13 +55,12 @@ jobs:
             CACHIX_CACHE_NAME=${{ vars.CACHIX_CACHE_NAME }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - uses: ./setup/
-        with:
-          digest: ${{ steps.build.outputs.digest }}
       - name: Smoke test
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          tinyalert --help
-          tinyalert \
+          docker images
+          docker run --rm -v $(pwd):/work $REGISTRY/$IMAGE_NAME@$DIGEST \
             --db tinyalert.sqlite \
             measure \
             --config integration/smoke.toml \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,9 @@ jobs:
           - "3.11"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: ${{ matrix.python-version }}
       - name: init pants
         uses: pantsbuild/actions/init-pants@main
         with:

--- a/integration/smoke.toml
+++ b/integration/smoke.toml
@@ -1,0 +1,7 @@
+[metrics.smoke]
+measure_source = "echo 1 | jq -r '.'"
+measure_type = "shell-raw"
+diffable_source = "echo 1"
+diffable_type = "shell"
+relative_min = 0
+epoch = 1

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -42,7 +42,7 @@ runs:
 
         bin_path = bin_dir / "tinyalert"
         script = """#!/usr/bin/env bash
-        exec docker run --rm -v $(pwd):/work {image_ref} "$@"
+        exec docker run --rm -v $(pwd):/work --env-file <(env | grep TINYALERT_) {image_ref} "$@"
         """.format(
             image_ref=shlex.quote(os.environ["image_ref"]),
         )

--- a/src/tinyalert/cli.py
+++ b/src/tinyalert/cli.py
@@ -130,6 +130,7 @@ def split_values(ctx, param, value):
     "config_path",
     type=click.Path(exists=True, path_type=Path),
     default="tinyalert.toml",
+    envvar=ENVVAR_PREFIX + "CONFIG",
     show_default=True,
 )
 @click.option(


### PR DESCRIPTION
The actual cause turned out to be  that `TINYALERT_DB_PATH` was not passed through to Docker.